### PR TITLE
libmusicbrainz5: use sha256 instead of md5

### DIFF
--- a/pkgs/development/libraries/libmusicbrainz/5.x.nix
+++ b/pkgs/development/libraries/libmusicbrainz/5.x.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/downloads/metabrainz/libmusicbrainz/${name}.tar.gz";
-    md5 = "a0406b94c341c2b52ec0fe98f57cadf3";
-  };
+    sha256 = "1mc2vfsnyky49s25yc64zijjmk4a8qgknqw21l5n58sra0f5x9qw";
+};
 
   dontUseCmakeBuildDir=true;
 


### PR DESCRIPTION
###### Motivation for this change

This fixes the recently added deprecation warning.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
